### PR TITLE
Fix FasterRCNN detector

### DIFF
--- a/vqpy/detector/faster_rcnn.py
+++ b/vqpy/detector/faster_rcnn.py
@@ -60,7 +60,7 @@ def postprocess(detections, image_size):
         rets.append({"tlbr": np.asarray(tlbr),
                      "score": score.item(),
                      "class_id": class_id})
-        return rets
+    return rets
 
 
 register("faster_rcnn", FasterRCNNDdetector, "FasterRCNN-10.onnx")

--- a/vqpy/detector/faster_rcnn.py
+++ b/vqpy/detector/faster_rcnn.py
@@ -59,7 +59,7 @@ def postprocess(detections, image_size):
         # todo: convert dict to named tuple
         rets.append({"tlbr": np.asarray(tlbr),
                      "score": score.item(),
-                     "class_id": class_id})
+                     "class_id": class_id - 1})
     return rets
 
 


### PR DESCRIPTION
class_id in FasterRCNN is offsetted by 1 when compared with `vqpy.utils.classes`